### PR TITLE
Fix ArrayIndexOutOfBoundsException with accessing tanks

### DIFF
--- a/src/main/java/vswe/stevescarts/blocks/tileentities/TileEntityDistributor.java
+++ b/src/main/java/vswe/stevescarts/blocks/tileentities/TileEntityDistributor.java
@@ -66,7 +66,8 @@ public class TileEntityDistributor extends TileEntityBase implements WorldlyCont
                 @Override
                 public int getTanks()
                 {
-                    return 4;
+                    final IFluidTank[] tanks = TileEntityDistributor.this.getTanks(facing);
+                    return tanks.length;
                 }
 
                 @Nonnull


### PR DESCRIPTION
Fixes this following server crash: https://gist.github.com/Drullkus/ffc3130322682793e99ea10d5f721c56